### PR TITLE
Nested Specs + Multi-generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,22 @@ npm install @helpscout/helix --save-dev
 ```
 
 
-## Quick Example
+## Getting started
+
+To get started, install Helix by entering the `npm` install command above (or use `yarn add`).
+
+Next, import both `createSpec` and `faker` from Helix to the file in your project.
+
+```js
+import { createSpec, faker } from '@helpscout/helix'
+```
+
+
+## Example
 
 The `createSpec` function is used to define your fixture spec. Helix comes with an adjusted version of [Faker.js](https://github.com/marak/Faker.js/), which also needs to be imported. Note, the API for Helix's faker is the **exact** same as Faker.js.
 
 ```js
-import { createSpec, faker } from '@helpscout/helix'
-
 const CustomerSpec = createSpec({
   id: faker.random.number()
   fname: faker.name.firstName()
@@ -47,8 +56,6 @@ Seeding allows you to consistently generate the same data based on a specific se
 To seed your Spec, use the `.seed()` method just before `.generate()`.
 
 ```js
-import { createSpec, faker } from '@helpscout/helix'
-
 const CustomerSpec = createSpec({
   id: faker.random.number()
   fname: faker.name.firstName()
@@ -61,7 +68,66 @@ const fixture = CustomerSpec.seed(12).generate()
 ```
 
 
+### Multi-generation
+
+You can generate multiple instances of your Spec fixture using the `generate()` method. All you have to do is pass in the number of instances you want generated!
+
+```js
+const Text = createSpec({
+  id: faker.random.number(),
+  message: faker.lorem.paragraph()
+})
+
+const fixture = Text.seed(50).generate()
+
+// Output
+// [{}, {}, {}, {}, {}]
+```
+
+#### Seeding
+
+To seed multi-generated fixtures, simply use the `.seed()` method before generating.
+
+```js
+const Text = createSpec({
+  id: faker.random.number(),
+  message: faker.lorem.paragraph()
+})
+
+const fixture = Text.seed(50).generate()
+```
+
+Note: Seed values aren't passed down from the parent Spec to children multi-specs.
+
+
+
+### Nesting
+
+Specs can be nested! In the example below, you can see that we've created 2 Specs: `MessageSpec` and `ConvoSpec`. Our `ConvoSpec` contains `MessageSpec` inside.
+
+```js
+const MessageSpec = createSpec({
+  id: faker.random.number(),
+  read: faker.random.boolean(),
+  message: faker.lorem.paragraph()
+})
+
+const ConvoSpec = createSpec({
+  id: faker.random.number(),
+  messages: MessageSpec.generate(5)
+})
+
+const fixture = ConvoSpec.generate()
+
+// Output
+// {
+//   id: 12341,
+//   messages: [{}, {}, {}, {}, {}]
+// }
+```
+
+
 ## TODO
 
-* [ ] Nested `Spec`s
 * [ ] Computed Faker values
+* [ ] Extend/override generated specs

--- a/package.json
+++ b/package.json
@@ -28,8 +28,7 @@
   "author": "ItsJonQ <itsjonq@gmail.com> (http://jonquach.com)",
   "dependencies": {
     "faker": "4.1.0",
-    "lodash": "4.17.4",
-    "prop-types": "15.6.0"
+    "lodash": "4.17.4"
   },
   "devDependencies": {
     "babel-cli": "6.24.1",

--- a/src/Spec/index.js
+++ b/src/Spec/index.js
@@ -1,6 +1,5 @@
 import faker from 'faker'
 import {
-  cloneDeep,
   isArray,
   isFunction,
   isNumber,
@@ -58,10 +57,10 @@ class HelixSpec {
  * @returns object
  */
 const generateSpecs = (shape) => {
-  return mapValues(cloneDeep(shape), (value, key) => {
+  return mapValues(shape, (value, key) => {
     // Preserve array structures
     if (isArray(value)) {
-      return value.map(v => generateSpecs(v))
+      return value.map(val => generateSpecs(val))
     }
     // Recurse
     if (isObject(value) && !isFunction(value)) {

--- a/src/Spec/index.js
+++ b/src/Spec/index.js
@@ -1,20 +1,33 @@
 import faker from 'faker'
-import { cloneDeep, isObject, isFunction, mapValues } from 'lodash'
+import { cloneDeep, isObject, isFunction, isNumber, mapValues } from 'lodash'
+import Exception from '../utils/log'
 
 class Spec {
   constructor (props) {
     this.props = props
+    this.seedNumber = null
     return this
   }
 
-  generate () {
-    const newProps = generateProps(this.props)
+  generate (count = 0) {
+    if (!isNumber(count)) {
+      throw Exception('Spec.generate()', 'Argument must be a valid number.')
+    }
+    const newProps = count ?
+      [...Array(count)].map(() => {
+        this.seed(this.seedNumber)
+        return generateProps(this.props)
+      }) :
+      generateProps(this.props)
+
+    this.seedNumber = null
     this.seed() // resets Faker
     return newProps
   }
 
   seed (number) {
-    faker.seed(number)
+    this.seedNumber = number
+    faker.seed(this.seedNumber)
     return this
   }
 }

--- a/src/Spec/tests/HelixSpec.test.js
+++ b/src/Spec/tests/HelixSpec.test.js
@@ -1,9 +1,18 @@
-import Spec from '..'
+import HelixSpec from '..'
 import faker from '../../faker'
 
 describe('generate', () => {
+  test('Throw if argument is invalid', () => {
+    const person = new HelixSpec({
+      id: faker.random.number()
+    })
+    expect(() => { person.generate(true) }).toThrow()
+    expect(() => { person.generate('name') }).toThrow()
+    expect(() => { person.generate(false) }).toThrow()
+  })
+
   test('Generates fixtures from a spec object', () => {
-    const person = new Spec({
+    const person = new HelixSpec({
       id: faker.random.number()
     })
     const fixture = person.generate()
@@ -12,7 +21,7 @@ describe('generate', () => {
   })
 
   test('Can generate multiple specs', () => {
-    const MessageSpec = new Spec({
+    const MessageSpec = new HelixSpec({
       id: faker.random.number(),
       read: faker.random.boolean(),
       timestamp: faker.date.past(),
@@ -24,40 +33,11 @@ describe('generate', () => {
     expect(Array.isArray(fixture)).toBeTruthy()
     expect(fixture[0].id).not.toBe(fixture[1].id)
   })
-
-  test('Can be nested', () => {
-    const MessageSpec = new Spec({
-      id: faker.random.number(),
-      read: faker.random.boolean(),
-      timestamp: faker.date.past(),
-      message: faker.lorem.paragraph()
-    })
-    const ConvoSpec = new Spec({
-      from: {
-        name: faker.name.firstName(),
-        email: faker.internet.email()
-      },
-      to: {
-        name: faker.name.firstName(),
-        email: faker.internet.email()
-      },
-      messages: MessageSpec.generate(5)
-    })
-
-    const fixture = ConvoSpec.generate()
-
-    expect(typeof fixture.from).toBe('object')
-    expect(typeof fixture.from.name).toBe('string')
-    expect(typeof fixture.from.email).toBe('string')
-    expect(typeof fixture.to).toBe('object')
-    expect(typeof fixture.to.name).toBe('string')
-    expect(typeof fixture.to.email).toBe('string')
-  })
 })
 
 describe('seed', () => {
   test('Can be set', () => {
-    const person = new Spec({
+    const person = new HelixSpec({
       name: faker.name.firstName()
     })
 
@@ -74,7 +54,7 @@ describe('seed', () => {
   })
 
   test('Is unaffected by external faker.seed', () => {
-    const person = new Spec({
+    const person = new HelixSpec({
       name: faker.name.firstName()
     })
 
@@ -94,7 +74,7 @@ describe('seed', () => {
   })
 
   test('Can generate multiple specs, but with the same seed', () => {
-    const MessageSpec = new Spec({
+    const MessageSpec = new HelixSpec({
       id: faker.random.number(),
       read: faker.random.boolean(),
       timestamp: faker.date.past(),
@@ -106,5 +86,4 @@ describe('seed', () => {
     expect(Array.isArray(fixture)).toBeTruthy()
     expect(fixture[0].id).toBe(fixture[1].id)
   })
-
 })

--- a/src/Spec/tests/Spec.test.js
+++ b/src/Spec/tests/Spec.test.js
@@ -10,6 +10,49 @@ describe('generate', () => {
 
     expect(fixture.id).toBeTruthy()
   })
+
+  test('Can generate multiple specs', () => {
+    const MessageSpec = new Spec({
+      id: faker.random.number(),
+      read: faker.random.boolean(),
+      timestamp: faker.date.past(),
+      message: faker.lorem.paragraph()
+    })
+
+    const fixture = MessageSpec.generate(5)
+
+    expect(Array.isArray(fixture)).toBeTruthy()
+    expect(fixture[0].id).not.toBe(fixture[1].id)
+  })
+
+  test('Can be nested', () => {
+    const MessageSpec = new Spec({
+      id: faker.random.number(),
+      read: faker.random.boolean(),
+      timestamp: faker.date.past(),
+      message: faker.lorem.paragraph()
+    })
+    const ConvoSpec = new Spec({
+      from: {
+        name: faker.name.firstName(),
+        email: faker.internet.email()
+      },
+      to: {
+        name: faker.name.firstName(),
+        email: faker.internet.email()
+      },
+      messages: MessageSpec.generate(5)
+    })
+
+    const fixture = ConvoSpec.generate()
+
+    expect(typeof fixture.from).toBe('object')
+    expect(typeof fixture.from.name).toBe('string')
+    expect(typeof fixture.from.email).toBe('string')
+    expect(typeof fixture.to).toBe('object')
+    expect(typeof fixture.to.name).toBe('string')
+    expect(typeof fixture.to.email).toBe('string')
+  })
 })
 
 describe('seed', () => {
@@ -49,4 +92,19 @@ describe('seed', () => {
     expect(two.name).not.toBe(three.name)
     expect(one.name).toBe(three.name)
   })
+
+  test('Can generate multiple specs, but with the same seed', () => {
+    const MessageSpec = new Spec({
+      id: faker.random.number(),
+      read: faker.random.boolean(),
+      timestamp: faker.date.past(),
+      message: faker.lorem.paragraph()
+    })
+
+    const fixture = MessageSpec.seed(4).generate(5)
+
+    expect(Array.isArray(fixture)).toBeTruthy()
+    expect(fixture[0].id).toBe(fixture[1].id)
+  })
+
 })

--- a/src/createSpec/index.js
+++ b/src/createSpec/index.js
@@ -1,13 +1,20 @@
 import { isObject } from 'lodash'
-import Spec from '../Spec'
+import HelixSpec from '../Spec'
 import { Exception } from '../utils/log'
 
+/**
+ * Creates the Spec "definition". Returns a HelixSpec class.
+ *
+ * @param object    $specs     Fixture shape, that contains Faker render API
+ *
+ * @returns class
+ */
 const createSpec = (specs) => {
   if (Array.isArray(specs) || !isObject(specs)) {
     throw new Exception('createSpec', 'Argument must be a valid object.')
   }
 
-  return new Spec(specs)
+  return new HelixSpec(specs)
 }
 
 export default createSpec

--- a/src/createSpec/tests/createSpec.test.js
+++ b/src/createSpec/tests/createSpec.test.js
@@ -43,3 +43,37 @@ test('Generates a Spec with multiple keys', () => {
   expect(typeof fixture.location.country).toBe('string')
   expect(typeof fixture.location.city).toBe('string')
 })
+
+test('Can generate nested Specs', () => {
+  const MessageSpec = createSpec({
+    id: faker.random.number(),
+    read: faker.random.boolean(),
+    timestamp: faker.date.past(),
+    message: faker.lorem.paragraph()
+  })
+
+  const ConvoSpec = createSpec({
+    from: {
+      name: faker.name.firstName(),
+      email: faker.internet.email()
+    },
+    to: {
+      name: faker.name.firstName(),
+      email: faker.internet.email()
+    },
+    messages: MessageSpec.generate(5)
+  })
+
+  const fixture = ConvoSpec.generate()
+
+  expect(typeof fixture.from).toBe('object')
+  expect(typeof fixture.from.name).toBe('string')
+  expect(typeof fixture.from.email).toBe('string')
+  expect(typeof fixture.to).toBe('object')
+  expect(typeof fixture.to.name).toBe('string')
+  expect(typeof fixture.to.email).toBe('string')
+  expect(Array.isArray(fixture.messages)).toBeTruthy()
+  expect(fixture.messages.length).toBe(5)
+  expect(typeof fixture.messages[0].id).toBe('number')
+  expect(typeof fixture.messages[0].message).toBe('string')
+})

--- a/src/faker/index.js
+++ b/src/faker/index.js
@@ -1,6 +1,15 @@
 import { cloneDeep, isObject, isFunction, mapValues } from 'lodash'
 import fakerLib from 'faker'
 
+/**
+ * Function remap the Faker class/object, to replace methods with functions
+ * that don't automatically execute. This function works recursively to walk
+ * down the entire Faker API tree.
+ *
+ * @param object    $object     Faker object/nested Faker object
+ *
+ * @returns object
+ */
 const remapFakerObject = (object) => {
   return mapValues(object, (value, key) => {
     if (isObject(value) && !isFunction(value)) {
@@ -13,8 +22,15 @@ const remapFakerObject = (object) => {
   })
 }
 
+/**
+ * Clones/enhances the Faker object
+ * @returns object
+ */
 const faker = remapFakerObject(cloneDeep(fakerLib))
-faker.fake = (...args) => fakerLib.fake(...args)
+
+// Required to mention Faker functionality
 faker.seed = (...args) => fakerLib.seed(...args)
+/* istanbul ignore next */
+faker.fake = (...args) => fakerLib.fake(...args)
 
 export default faker

--- a/src/faker/index.js
+++ b/src/faker/index.js
@@ -1,4 +1,4 @@
-import { cloneDeep, isObject, isFunction, mapValues } from 'lodash'
+import { isObject, isFunction, mapValues } from 'lodash'
 import fakerLib from 'faker'
 
 /**
@@ -26,7 +26,7 @@ const remapFakerObject = (object) => {
  * Clones/enhances the Faker object
  * @returns object
  */
-const faker = remapFakerObject(cloneDeep(fakerLib))
+const faker = remapFakerObject(Object.assign({}, fakerLib))
 
 // Required to mention Faker functionality
 faker.seed = (...args) => fakerLib.seed(...args)

--- a/src/faker/tests/faker.test.js
+++ b/src/faker/tests/faker.test.js
@@ -8,15 +8,17 @@ test('Methods should return functions', () => {
   expect(typeof results).toBe('number')
 })
 
-test('Seed method should work', () => {
-  faker.seed(1)
-  const one = faker.random.number()()
-  faker.seed(2)
-  const two = faker.random.number()()
-  faker.seed(1)
-  const three = faker.random.number()()
+describe('seed', () => {
+  test('Seed method should work', () => {
+    faker.seed(1)
+    const one = faker.random.number()()
+    faker.seed(2)
+    const two = faker.random.number()()
+    faker.seed(1)
+    const three = faker.random.number()()
 
-  expect(one).not.toBe(two)
-  expect(two).not.toBe(three)
-  expect(one).toBe(one)
+    expect(one).not.toBe(two)
+    expect(two).not.toBe(three)
+    expect(one).toBe(one)
+  })
 })

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,2 @@
-export { default as Spec } from './Spec'
 export { default as createSpec } from './createSpec'
 export { default as faker } from './faker'

--- a/src/tests/index.test.js
+++ b/src/tests/index.test.js
@@ -1,0 +1,12 @@
+import {
+  createSpec,
+  faker
+} from '..'
+
+test('createSpec should be exported', () => {
+  expect(createSpec).toBeTruthy()
+})
+
+test('faker should be exported', () => {
+  expect(faker).toBeTruthy()
+})

--- a/src/utils/log.js
+++ b/src/utils/log.js
@@ -9,6 +9,7 @@ import { isString } from 'lodash'
  * @returns function
  */
 
+/* istanbul ignore next */
 const logWrapper = fn => /* istanbul ignore next */ message => {
   /* istanbul ignore next */
   if (process.env.NODE_ENV !== 'test') {
@@ -17,26 +18,29 @@ const logWrapper = fn => /* istanbul ignore next */ message => {
 }
 
 /* istanbul ignore next */
-export const log = message => {
+export const log = /* istanbul ignore next */ message => {
   /* istanbul ignore next */
   return logWrapper(console.log, message)
 }
 
 /* istanbul ignore next */
-export const warn = message => {
+export const warn = /* istanbul ignore next */ message => {
   /* istanbul ignore next */
   return logWrapper(console.warn, message)
 }
 
 /* istanbul ignore next */
-export const error = message => {
+export const error = /* istanbul ignore next */ message => {
   /* istanbul ignore next */
   return logWrapper(console.error, message)
 }
 
+/* istanbul ignore next */
 export const Exception = (methodName, message) => {
+  /* istanbul ignore next */
   if (!isString(methodName) || !isString(message)) {
     warn('helix: Exception(): Arguments need to be strings.')
   }
+  /* istanbul ignore next */
   this.message = `helix: ${methodName}(): ${message}`
 }


### PR DESCRIPTION
## Nested Specs + Multi-generation

This updates Helix to support nested Specs, as well as the ability to
very easily generate multiple instances of a Spec.

### Multi-generation

You can generate multiple instances of your Spec fixture using the `generate()` method. All you have to do is pass in the number of instances you want generated!

```js
const Text = createSpec({
  id: faker.random.number(),
  message: faker.lorem.paragraph()
})

const fixture = Text.seed(50).generate()

// Output
// [{}, {}, {}, {}, {}]
```

#### Seeding

To seed multi-generated fixtures, simply use the `.seed()` method before generating.

```js
const Text = createSpec({
  id: faker.random.number(),
  message: faker.lorem.paragraph()
})

const fixture = Text.seed(50).generate()
```

Note: Seed values aren't passed down from the parent Spec to children multi-specs.



### Nesting

Specs can be nested! In the example below, you can see that we've created 2 Specs: `MessageSpec` and `ConvoSpec`. Our `ConvoSpec` contains `MessageSpec` inside.

```js
const MessageSpec = createSpec({
  id: faker.random.number(),
  read: faker.random.boolean(),
  message: faker.lorem.paragraph()
})

const ConvoSpec = createSpec({
  id: faker.random.number(),
  messages: MessageSpec.generate(5)
})

const fixture = ConvoSpec.generate()

// Output
// {
//   id: 12341,
//   messages: [{}, {}, {}, {}, {}]
// }
```


Tests coverage should now be at 100%!

Internally, `deepClone` has also been dropped for a speed boost! 🚀 