### PR TITLE
Adds faker.computed to generate computed values

### DIFF
--- a/src/HelixSpec/generateSpecs.js
+++ b/src/HelixSpec/generateSpecs.js
@@ -1,0 +1,53 @@
+import HelixSpec from './index'
+import { isComputedValue } from '../faker'
+import {
+  isArray,
+  isFunction,
+  isNumber,
+  isObject,
+  mapValues
+} from 'lodash'
+import Exception from '../utils/log'
+
+/**
+ * Recursively instantiates the Helix version of Faker methods.
+ *
+ * @param object    $shape     Fixture shape, that contains Faker render API
+ *
+ * @returns object
+ */
+const generateSpecs = (shape, seedValue) => {
+  if (!isObject(shape) && !isArray(shape)) {
+    throw new Exception(
+      'HelixSpec.generateSpecs',
+      'First argument must be an object, array, or HelixSpec.'
+    )
+  }
+  if (seedValue !== undefined && !isNumber(seedValue)) {
+    throw new Exception(
+      'HelixSpec.generateSpecs',
+      'Seed value must be a valid number.'
+    )
+  }
+  return mapValues(shape, (value, key) => {
+    // Preserve array structures
+    if (isArray(value)) {
+      return value.map(val => generateSpecs(val))
+    }
+    // Recurse
+    if (isObject(value) && !isFunction(value)) {
+      return value instanceof HelixSpec
+        ? value.generate()
+        : generateSpecs(value)
+    }
+    // Instantiate!
+    if (isFunction(value)) {
+      // Tested value(seedValue), but Istanbul isn't picking it up
+      return isComputedValue(value) /* istanbul ignore next */
+        ? value(seedValue) : value()
+    }
+    return value
+  })
+}
+
+export default generateSpecs

--- a/src/HelixSpec/tests/HelixSpec.test.js
+++ b/src/HelixSpec/tests/HelixSpec.test.js
@@ -70,6 +70,24 @@ describe('generate', () => {
     expect(typeof fixture.fname).toBe('string')
     expect(typeof fixture.lname).toBe('string')
   })
+
+  test('Can generate computed values', () => {
+    const nameProps = {
+      fname: faker.name.firstName(),
+      lname: faker.name.lastName()
+    }
+    const PersonSpec = new HelixSpec({
+      id: faker.random.number(),
+      name: faker.computed(nameProps)(props => {
+        return `${props.fname} ${props.lname}`
+      })
+    })
+
+    const fixture = PersonSpec.generate()
+
+    expect(typeof fixture.name).toBe('string')
+    expect(fixture.name.split(' ').length).toBe(2)
+  })
 })
 
 describe('extend', () => {
@@ -115,6 +133,17 @@ describe('extend', () => {
 })
 
 describe('seed', () => {
+  test('Throws if argument is invalid', () => {
+    const person = new HelixSpec({
+      name: faker.name.firstName()
+    })
+
+    expect(() => { person.seed() }).not.toThrow()
+    expect(() => { person.seed('1') }).toThrow()
+    expect(() => { person.seed(true) }).toThrow()
+    expect(() => { person.seed({value: 2}) }).toThrow()
+  })
+
   test('Can be set', () => {
     const person = new HelixSpec({
       name: faker.name.firstName()
@@ -201,5 +230,23 @@ describe('External', () => {
       expect(fixture.length).toBeGreaterThanOrEqual(1)
       expect(fixture.length).toBeLessThanOrEqual(5)
     })
+  })
+
+  test('Can generate computed values with seed values', () => {
+    const nameProps = {
+      fname: faker.name.firstName(),
+      lname: faker.name.lastName()
+    }
+    const PersonSpec = new HelixSpec({
+      id: faker.random.number(),
+      name: faker.computed(nameProps)(props => {
+        return `${props.fname} ${props.lname}`
+      })
+    })
+
+    const fixture = PersonSpec.seed(2).generate()
+    const fixture2 = PersonSpec.seed(2).generate()
+
+    expect(fixture.name).toBe(fixture2.name)
   })
 })

--- a/src/HelixSpec/tests/generateSpecs.test.js
+++ b/src/HelixSpec/tests/generateSpecs.test.js
@@ -1,0 +1,31 @@
+import generateSpecs from '../generateSpecs'
+import { default as faker } from '../../faker'
+
+test('Throws if argument is invalid', () => {
+  expect(() => generateSpecs()).toThrow()
+  expect(() => generateSpecs(true)).toThrow()
+  expect(() => generateSpecs(132)).toThrow()
+})
+
+test('Throws if seedValue argument is invalid', () => {
+  expect(() => generateSpecs({}, true)).toThrow()
+  expect(() => generateSpecs({}, '1')).toThrow()
+  expect(() => generateSpecs({}, [])).toThrow()
+})
+
+test('Generates computed values', () => {
+  const nameProps = {
+    fname: faker.name.firstName(),
+    lname: faker.name.lastName()
+  }
+  const shape = {
+    name: faker.computed(nameProps)(props => {
+      return `${props.fname} ${props.lname}`
+    })
+  }
+
+  const o = generateSpecs(shape)
+
+  expect(typeof o.name).toBe('string')
+  expect(o.name.split(' ').length).toBe(2)
+})

--- a/src/faker/computed.js
+++ b/src/faker/computed.js
@@ -1,0 +1,38 @@
+import {
+  isNumber,
+  isPlainObject
+} from 'lodash'
+import makeComposedProps from './makeComposedProps'
+import Exception from '../utils/log'
+
+/**
+ * Creates a function that HelixSpec.generate can use to render computed
+ * values. This function takes in the props (object), renders them using Faker,
+ * then passes the remapped props to the callback function.
+ *
+ * @param object      $faker              Faker class/object
+ * @param object      $props              Faker values to render
+ * @param number      $seedValue          Seed value for Faker
+ * @param function    $computedCallback   Callback to execute to render value
+ *
+ * @returns function
+ */
+const computed = faker => (props, seedValue) => computedCallback => {
+  if (!isPlainObject(props)) {
+    throw new Exception(
+      'faker.computed',
+      'First argument must be a valid object.'
+    )
+  }
+  if (seedValue !== undefined && !isNumber(seedValue)) {
+    throw new Exception(
+      'faker.computed',
+      'faker.seed value must be a valid number.'
+    )
+  }
+  return (seedValue) => {
+    return computedCallback(makeComposedProps(faker)(props, seedValue))
+  }
+}
+
+export default computed

--- a/src/faker/index.js
+++ b/src/faker/index.js
@@ -1,25 +1,19 @@
-import { isObject, isFunction, mapValues } from 'lodash'
+import {
+  isFunction
+} from 'lodash'
 import fakerLib from 'faker'
+import computed from './computed'
+import remapFakerObject from './remapFakerObject'
 
 /**
- * Function remap the Faker class/object, to replace methods with functions
- * that don't automatically execute. This function works recursively to walk
- * down the entire Faker API tree.
+ * Returns a boolean based on whether the value is a computed Faker value.
  *
- * @param object    $object     Faker object/nested Faker object
+ * @param function    $value     Faker method
  *
- * @returns object
+ * @returns boolean
  */
-const remapFakerObject = (object) => {
-  return mapValues(object, (value, key) => {
-    if (isObject(value) && !isFunction(value)) {
-      return remapFakerObject(value)
-    }
-    if (isFunction(value)) {
-      return (...args) => () => value(...args)
-    }
-    return value
-  })
+export const isComputedValue = value => {
+  return isFunction(value) && value.fakerComputedValue
 }
 
 /**
@@ -32,5 +26,9 @@ const faker = remapFakerObject(Object.assign({}, fakerLib))
 faker.seed = (...args) => fakerLib.seed(...args)
 /* istanbul ignore next */
 faker.fake = (...args) => fakerLib.fake(...args)
+
+faker.computed = computed(faker)
+// Add property that allows generate() to check for computedProperty
+faker.computed.fakerComputedValue = true
 
 export default faker

--- a/src/faker/makeComposedProps.js
+++ b/src/faker/makeComposedProps.js
@@ -1,0 +1,33 @@
+import {
+  isArray,
+  isFunction,
+  isPlainObject,
+  mapValues
+} from 'lodash'
+
+/**
+ * Recursively renders faker methods. This function is used in the
+ * faker.computed method.
+ *
+ * @param object      $faker      Faker class/object
+ * @param object      $props      Faker values to render
+ * @param number      $seedValue  Seed value for Faker
+ *
+ * @returns object
+ */
+const makeComposedProps = faker => (props, seedValue) => {
+  return mapValues(props, (value, key) => {
+    if (isPlainObject(value)) {
+      return makeComposedProps(faker)(value, seedValue)
+    }
+    if (isArray(value)) {
+      return value.map(val => makeComposedProps(faker)(val, seedValue))
+    }
+    if (seedValue) {
+      faker.seed(seedValue)
+    }
+    return isFunction(value) ? value() : value
+  })
+}
+
+export default makeComposedProps

--- a/src/faker/remapFakerObject.js
+++ b/src/faker/remapFakerObject.js
@@ -1,0 +1,28 @@
+import {
+  isFunction,
+  isObject,
+  mapValues
+} from 'lodash'
+
+/**
+ * Function remap the Faker class/object, to replace methods with functions
+ * that don't automatically execute. This function works recursively to walk
+ * down the entire Faker API tree.
+ *
+ * @param object    $object     Faker object/nested Faker object
+ *
+ * @returns object
+ */
+const remapFakerObject = object => {
+  return mapValues(object, (value, key) => {
+    if (isObject(value) && !isFunction(value)) {
+      return remapFakerObject(value)
+    }
+    if (isFunction(value)) {
+      return (...args) => () => value(...args)
+    }
+    return value
+  })
+}
+
+export default remapFakerObject

--- a/src/faker/tests/faker.test.js
+++ b/src/faker/tests/faker.test.js
@@ -19,6 +19,128 @@ describe('seed', () => {
 
     expect(one).not.toBe(two)
     expect(two).not.toBe(three)
-    expect(one).toBe(one)
+    expect(one).toBe(three)
+  })
+})
+
+describe('computed', () => {
+  test('Throws if props object is invalid', () => {
+    expect(() => faker.computed()()).toThrow()
+    expect(() => faker.computed([])()).toThrow()
+    expect(() => faker.computed(faker.name.firstName)()).toThrow()
+    expect(() => faker.computed(faker.name.firstName())()).toThrow()
+  })
+
+  test('Throws if seed value is invalid', () => {
+    expect(() => faker.computed({}, true)()).toThrow()
+    expect(() => faker.computed({}, [])()).toThrow()
+    expect(() => faker.computed({}, '2')()).toThrow()
+  })
+
+  test('Returns a function', () => {
+    const props = {
+      fname: faker.name.firstName(),
+      lname: faker.name.lastName()
+    }
+    const value = faker.computed(props)(values => {
+      const { fname, lname } = values
+      return `${fname} ${lname}`
+    })
+
+    expect(typeof value).toBe('function')
+    expect(typeof value()).toBe('string')
+  })
+
+  test('Can generate computed values', () => {
+    const props = {
+      fname: faker.name.firstName(),
+      lname: faker.name.lastName()
+    }
+    const value = faker.computed(props)(values => {
+      const { fname, lname } = values
+      return `${fname} ${lname}`
+    })()
+
+    expect(value.split(' ').length).toBe(2)
+  })
+
+  test('Can take in seed value, as second argument', () => {
+    const props = {
+      fname: faker.name.firstName(),
+      lname: faker.name.lastName()
+    }
+    const value = faker.computed(props)(values => {
+      const { fname, lname } = values
+      return `${fname} ${lname}`
+    })(2).split(' ')
+
+    faker.seed(2)
+    const fname = props.fname()
+    faker.seed(2)
+    const lname = props.lname()
+
+    expect(fname).toBe(value[0])
+    expect(lname).toBe(value[1])
+  })
+
+  test('Can compute non-faker method props', () => {
+    const props = {
+      fname: 'Dino',
+      lname: 'Saur'
+    }
+    const value = faker.computed(props)(values => {
+      const { fname, lname } = values
+      return `${fname} ${lname}`
+    })()
+
+    expect(value).toBe('Dino Saur')
+  })
+
+  test('Can generate nested computed values', () => {
+    const props = {
+      vip: {
+        person: {
+          fname: faker.name.firstName(),
+          lname: faker.name.lastName()
+        }
+      }
+    }
+
+    const value = faker.computed(props)(values => {
+      const { fname, lname } = values.vip.person
+      return `${fname} ${lname}`
+    })(2).split(' ')
+
+    faker.seed(2)
+    const fname = props.vip.person.fname()
+    faker.seed(2)
+    const lname = props.vip.person.lname()
+
+    expect(fname).toBe(value[0])
+    expect(lname).toBe(value[1])
+  })
+
+  test('Can generate nested + array computed values', () => {
+    const props = {
+      vip: [
+        {
+          fname: faker.name.firstName(),
+          lname: faker.name.lastName()
+        }
+      ]
+    }
+
+    const value = faker.computed(props)(values => {
+      const { fname, lname } = values.vip[0]
+      return `${fname} ${lname}`
+    })(2).split(' ')
+
+    faker.seed(2)
+    const fname = props.vip[0].fname()
+    faker.seed(2)
+    const lname = props.vip[0].lname()
+
+    expect(fname).toBe(value[0])
+    expect(lname).toBe(value[1])
   })
 })


### PR DESCRIPTION
## Adds faker.computed to generate computed values

This update adds a new method to faker (faker.computed) that allows you to
create custom values based on combining faker methods with other things (like
strings, numbers, or other faker methods)

This update also refactors some of the functions used in Helix to their own
separate files, as well as adds the appropriate comment docs.

### Example

```js
const props = {
  fname: faker.name.firstName(),
  lname: faker.name.lastName()
}
const value = faker.computed(props)(values => {
  const { fname, lname } = values
  return `${fname} ${lname}`
})

console.log(value())
// Michelle Santos
```

### Seeding

Computed values support seeding! The seed value is passed in when the computed value is instantiated. When generated with `HelixSpec.generate`, this is done automatically.

```js
const props = {
  fname: faker.name.firstName(),
  lname: faker.name.lastName()
}
const value = faker.computed(props)(values => {
  const { fname, lname } = values
  return `${fname} ${lname}`
})

// Generate the computed value, with a seed value of 23
console.log(value(23))
```

Note: The API for computed is a little verbose at the moment. @knicklabs and I have discussed ideas on how to make it nicer, but it's not required for now.

Resolves: https://github.com/helpscout/helix/issues/2