### PR TITLE
Support single value HelixSpecs

### DIFF
--- a/docs/guides/create-spec.md
+++ b/docs/guides/create-spec.md
@@ -29,6 +29,18 @@ The default Faker methods would have rendered some nice fixture data for you the
 
 The actually render the fixture data, we'll need to generate it.
 
+## Single-value Specs
+You can also create a HelixSpec which generates a single value. For example, if you have a data type UserType with a set of constant values, you can create a spec to capture this like so:
+
+```js
+const UserType = createSpec(faker.random.arrayElement(['user', 'guest', 'admin']))
+const User = createSpec({
+  id: faker.random.number(),
+  name: faker.name.firstName(),
+  location: faker.address.country(),
+  type: UserType
+})
+```
 
 ## Generating fixture data
 

--- a/docs/guides/create-spec.md
+++ b/docs/guides/create-spec.md
@@ -29,18 +29,26 @@ The default Faker methods would have rendered some nice fixture data for you the
 
 The actually render the fixture data, we'll need to generate it.
 
+
 ## Single-value Specs
-You can also create a HelixSpec which generates a single value. For example, if you have a data type UserType with a set of constant values, you can create a spec to capture this like so:
+
+You can also create a HelixSpec which generates a single value. For example, if you have a data type `DinoType` with a set of constant values, you can create a spec to capture this like so:
 
 ```js
-const UserType = createSpec(faker.random.arrayElement(['user', 'guest', 'admin']))
-const User = createSpec({
+const DinoType = createSpec(faker.random.arrayElement([
+  'tyrannosaurus-rex',
+  'velocirapter',
+  'stegosaurus'
+]))
+
+const Dinosaur = createSpec({
   id: faker.random.number(),
   name: faker.name.firstName(),
   location: faker.address.country(),
-  type: UserType
+  type: DinoType
 })
 ```
+
 
 ## Generating fixture data
 

--- a/src/HelixSpec/generateSpecs.js
+++ b/src/HelixSpec/generateSpecs.js
@@ -29,6 +29,12 @@ const generateSpecs = (shape, seedValue) => {
       'Seed value must be a valid number.'
     )
   }
+  if (isFunction(shape)) {
+    // Tested value(seedValue), but Istanbul isn't picking it up
+    return isComputedValue(shape) /* istanbul ignore next */
+      ? shape(seedValue) : shape()
+  }
+
   return mapValues(shape, (value, key) => {
     // Preserve array structures
     if (isArray(value)) {

--- a/src/HelixSpec/tests/HelixSpec.test.js
+++ b/src/HelixSpec/tests/HelixSpec.test.js
@@ -30,6 +30,18 @@ describe('generate', () => {
     expect(generate).toBeLessThanOrEqual(103)
   })
 
+  test('Can use single-value spec inside another Spec', () => {
+    const UserType = new HelixSpec(faker.random.arrayElement(['user', 'guest', 'admin']))
+    const User = new HelixSpec({
+      id: faker.random.number(),
+      name: faker.name.firstName(),
+      location: faker.address.country(),
+      type: UserType
+    })
+    const user = User.generate()
+    expect(user.type).toMatch(/(user)|(guest)|(admin)/)
+  })
+
   test('Throw if max argument is less than count argument', () => {
     const person = new HelixSpec({
       id: faker.random.number()

--- a/src/HelixSpec/tests/HelixSpec.test.js
+++ b/src/HelixSpec/tests/HelixSpec.test.js
@@ -22,6 +22,14 @@ describe('generate', () => {
     expect(() => { person.generate(1, false) }).toThrow()
   })
 
+  test('Can create a spec from a single function', () => {
+    const randomNumber = new HelixSpec(faker.random.number({ min: 100, max: 103 }))
+    const generate = randomNumber.generate()
+    expect(typeof generate).toBe('number')
+    expect(generate).toBeGreaterThanOrEqual(100)
+    expect(generate).toBeLessThanOrEqual(103)
+  })
+
   test('Throw if max argument is less than count argument', () => {
     const person = new HelixSpec({
       id: faker.random.number()


### PR DESCRIPTION
## Support single value HelixSpecs 

### Feature
This PR allows the creation of HelixSpecs which return a single value. For example:

```javascript
const UserType = new HelixSpec(faker.random.arrayElement(['user', 'guest', 'admin']))
const User = new HelixSpec({
  id: faker.random.number(),
  name: faker.name.firstName(),
  location: faker.address.country(),
  type: UserType
})
```