### PR TITLE
Fix bug where `Spec.generate(0, 3)` returns a non-array if the random count is 0

### DIFF
--- a/src/HelixSpec/index.js
+++ b/src/HelixSpec/index.js
@@ -38,7 +38,9 @@ class HelixSpec {
       count = faker.random.number({min: count, max})
     }
 
-    const generatedSpecs = count
+    // If count was 0, max was specified, but the randomized count comes back 0, return []
+    const isArray = count || max !== undefined
+    const generatedSpecs = isArray
       ? [...Array(count)].map(() => {
         // Respect seed value for multi-generated specs
         this.seed(this.seedValue)

--- a/src/HelixSpec/tests/HelixSpec.test.js
+++ b/src/HelixSpec/tests/HelixSpec.test.js
@@ -32,11 +32,11 @@ describe('External', () => {
       message: faker.lorem.paragraph()
     })
 
-    times(10, (index) => {
-      const fixture = MessageSpec.seed(index).generate(1, 5)
+    times(20, (index) => {
+      const fixture = MessageSpec.seed(index).generate(0, 3)
       expect(Array.isArray(fixture)).toBeTruthy()
-      expect(fixture.length).toBeGreaterThanOrEqual(1)
-      expect(fixture.length).toBeLessThanOrEqual(5)
+      expect(fixture.length).toBeGreaterThanOrEqual(0)
+      expect(fixture.length).toBeLessThanOrEqual(3)
     })
   })
 


### PR DESCRIPTION
## Problem
`Spec.generate(0,3)` wasn't returning `[]` when the random count was 0. Was treating the same as if we called `Spec.generate()` and returned a single spec instance, which is wrong. 