### PR TITLE
Add new derived() function for better computeds

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -24,5 +24,6 @@ A more in-depth look at Helix's functions and methods
 
 * [HelixSpec](./api/HelixSpec)
 * [compose](./api/compose.md)
+* [derived](./api/derived.md)
 * [faker](./api/faker)
-* [oneOf](./api/oneOf)
+* [oneOf](./api/oneOf.md)

--- a/docs/api/derived.md
+++ b/docs/api/derived.md
@@ -1,0 +1,33 @@
+# `derived(mapper({...props} => callback))`
+
+To have more control over your computed values, you can use the `derived` function. It provides access to existing [HelixSpec](./HelixSpec)'s Spec shape properties to create new computed outputs.
+
+**Note: `derived()` was created as a replacement for `[faker.computed](./faker/computed.md)`.**
+
+### Arguments
+
+| Argument | Type | Description |
+| --- | --- | --- |
+| `mapper` | `function` | Function for `derived` to instantiate. |
+| `{...props}` | `object` | Argument provided by `mapper`, containing existing props within the Spec shape. |
+| `callback` | `function` | Callback function that allows you to work with the Faker rendered data. |
+
+
+### Returns
+
+`Any`: Returns whatever you determine in the `callback` function.
+
+
+### Example
+
+```js
+import { createSpec, faker } from '@helpscout/helix'
+
+const Spec = createSpec({
+  fname: faker.name.firstName(), // Alice
+  lname: faker.name.lastName(), // Baker
+  name: derived(({ fname, lname }) => `${fname} ${lname}`)
+})
+
+const fixture = Spec.generate() // Alice Baker
+```

--- a/docs/api/derived.md
+++ b/docs/api/derived.md
@@ -2,7 +2,7 @@
 
 To have more control over your computed values, you can use the `derived` function. It provides access to existing [HelixSpec](./HelixSpec)'s Spec shape properties to create new computed outputs.
 
-**Note: `derived()` was created as a replacement for `[faker.computed](./faker/computed.md)`.**
+**Note: `derived()` was created as a replacement for [`faker.computed`](./faker/computed.md).**
 
 ### Arguments
 

--- a/docs/api/faker/README.md
+++ b/docs/api/faker/README.md
@@ -22,5 +22,4 @@ For a **full list** of all the available Faker methods, **[check out their docum
 
 Helix has enhanced Faker with a couple of methods:
 
-* [computed](./computed.md)
 * [fake](./fake.md)

--- a/docs/api/faker/computed.md
+++ b/docs/api/faker/computed.md
@@ -2,6 +2,8 @@
 
 To have more control over your computed values, you can use the `faker.computed()` method. `computed()` is a special method Helix has extended onto Faker.js, and isn't available in the default Faker.js library.
 
+**Note: `faker.computed()` has been deprecated. Please use `[derived()](../derived.md)` instead.**
+
 ### Arguments
 
 | Argument | Type | Description |

--- a/docs/api/faker/computed.md
+++ b/docs/api/faker/computed.md
@@ -2,7 +2,7 @@
 
 To have more control over your computed values, you can use the `faker.computed()` method. `computed()` is a special method Helix has extended onto Faker.js, and isn't available in the default Faker.js library.
 
-**Note: `faker.computed()` has been deprecated. Please use `[derived()](../derived.md)` instead.**
+**Note: `faker.computed()` has been deprecated. Please use [`derived()`](../derived.md) instead.**
 
 ### Arguments
 

--- a/docs/guides/composing.md
+++ b/docs/guides/composing.md
@@ -110,10 +110,10 @@ MutantMechaDinosaur.generate()
 
 ## Variable type Specs
 
-Sometimes, a spec needs a value which can be one of several different types. This can easily be accomplished with the `oneof` helper
+Sometimes, a spec needs a value which can be one of several different types. This can easily be accomplished with the `oneOf` helper
 
 ```js
-import { oneof, createSpec, faker } from '@helpscout/helix'
+import { oneOf, createSpec, faker } from '@helpscout/helix'
 
 const Tyrannosaurus = createSpec({
   id: faker.random.number(),

--- a/docs/guides/computed.md
+++ b/docs/guides/computed.md
@@ -33,42 +33,12 @@ If you want something that's more flexible with **ultimate control**, check out 
 
 ## Hard-mode
 
-To have more control over your computed values, you can use the `faker.computed()` method. `computed()` is a special method Helix has extended onto Faker.js, and isn't available in the default Faker.js library.
+To have more control over your computed values, you can use the `derived()` function.
 
-The `faker.computed()` method accepts a single argument (`object`), that contains a shape of the data you'd like to work with. In the example below, we're only using `name`. You can add as many as you want (and nest as deeply as you want).
-
-```js
-import { createSpec, faker } from '@helpscout/helix'
-
-const props = {
-  name: faker.name.firstName()
-}
-```
-
-After you pass the `props` into `faker.computed()`, instantiate a curried function with an argument of `values` (or whatever you'd like to name it).
-The `values` argument is your `props` object remapped with Faker generated content!
+In the example below, we're only using `name`. You can add as many as you want (and nest as deeply as you want).
 
 ```js
-faker.computed(props)(values => {
-// values is…
-// {
-//   name: 'Abigail'
-// }
-})
-```
-
-The last step is to return **whatever content you want** for your computed value. In this example, we'll take our Faker generated firstName, make it all uppercase, and add a space between every letter.
-
-```js
-faker.computed(props)(values => {
-  return values.name.toUpperCase().split('').join(' ')
-})
-```
-
-The complete example looks something like this:
-
-```js
-import { createSpec, faker } from '@helpscout/helix'
+import { createSpec, derived, faker } from '@helpscout/helix'
 
 const props = {
   name: faker.name.firstName()
@@ -76,15 +46,20 @@ const props = {
 
 const Dinosaur = createSpec({
   id: faker.random.number(),
-  fullName: faker.computed(props)(values => {
-    return values.name.toUpperCase().split('').join(' ')
+  firstName: faker.name.firstName(),
+  lastName: faker.name.lastName(),
+  fancyName: derived((props => {
+    const { firstName } = props
+    return firstName.toUpperCase().split('').join(' ')
   })
 })
 
 Dinosaur.generate()
 // {
 //   id: 324191,
-//   fullName: 'A B I G A I L'
+//   firstName: 'Abigail',
+//   lastName: 'Baker',
+//   fancyName: 'A B I G A I L'
 // }
 ```
 

--- a/src/HelixSpec/generateSpecs.js
+++ b/src/HelixSpec/generateSpecs.js
@@ -30,9 +30,7 @@ const generateSpecs = (shape, seedValue) => {
     )
   }
   if (isFunction(shape)) {
-    // Tested value(seedValue), but Istanbul isn't picking it up
-    return isComputedValue(shape) /* istanbul ignore next */
-      ? shape(seedValue) : shape()
+    return isComputedValue(shape) ? shape(seedValue) : shape()
   }
   if (shape instanceof HelixSpec) {
     return shape.generate()

--- a/src/HelixSpec/tests/generateSpecs.test.js
+++ b/src/HelixSpec/tests/generateSpecs.test.js
@@ -29,3 +29,15 @@ test('Generates computed values', () => {
   expect(typeof o.name).toBe('string')
   expect(o.name.split(' ').length).toBe(2)
 })
+
+test('Generates single computed value', () => {
+  const props = {
+    fname: faker.name.firstName(),
+    lname: faker.name.lastName()
+  }
+  const fixture = generateSpecs(faker.computed(props)(values => {
+    return `${values.fname} ${values.lname}`
+  }))
+
+  expect(fixture.split(' ').length).toBe(2)
+})

--- a/src/derived/index.js
+++ b/src/derived/index.js
@@ -1,0 +1,9 @@
+export const isDerivedValue = (generator) => generator.isDerivedValue
+
+const derived = (mapper) => {
+  const generator = (shape) => mapper(shape)
+  generator.isDerivedValue = true
+  return generator
+}
+
+export default derived

--- a/src/derived/tests/derived.test.js
+++ b/src/derived/tests/derived.test.js
@@ -1,0 +1,62 @@
+import createSpec from '../../createSpec'
+import faker from '../../faker'
+import derived from '..'
+
+test('Can combine simple props', () => {
+  const Spec = createSpec({
+    fname: () => 'Alice',
+    lname: () => 'Baker',
+    name: derived(({ fname, lname }) => `${fname} ${lname}`)
+  })
+  const fixture = Spec.generate()
+
+  expect(fixture.name).toBe('Alice Baker')
+})
+
+test('Can have multiple derived', () => {
+  const Spec = createSpec({
+    fname: () => 'Alice',
+    lname: () => 'Baker',
+    rollCall: derived(({ fname, lname }) => `${lname}, ${fname}`),
+    fancyName: derived(({ fname }) => fname.split('').join('*').toUpperCase())
+  })
+  const fixture = Spec.generate()
+
+  expect(fixture.rollCall).toBe('Baker, Alice')
+  expect(fixture.fancyName).toBe('A*L*I*C*E')
+})
+
+test('Can remap over a derived array', () => {
+  const Spec = createSpec({
+    numbers: () => [1, 2, 3],
+    total: derived(({ numbers }) => numbers.reduce((sum, x) => sum + x))
+  })
+  const fixture = Spec.generate()
+
+  expect(fixture.total).toBe(6)
+})
+
+test('Derived props are invisible to each other during generate', () => {
+  const Spec = createSpec({
+    chickens: faker.random.number(),
+    horses: faker.random.number(),
+    A: derived(({ B }) => typeof B === 'undefined'),
+    B: derived(({ A }) => typeof A === 'undefined')
+  })
+  const fixture = Spec.generate()
+
+  expect(fixture.A).toBe(true)
+  expect(fixture.B).toBe(true)
+})
+
+test('Derived props should respect seed values', () => {
+  const Spec = createSpec({
+    fname: faker.name.firstName(),
+    lname: faker.name.lastName(),
+    name: derived(({ fname, lname }) => `${fname} ${lname}`)
+  })
+  const fixtureA = Spec.seed(2).generate()
+  const fixtureB = Spec.seed(2).generate()
+
+  expect(fixtureA.name).toBe(fixtureB.name)
+})

--- a/src/faker/computed.js
+++ b/src/faker/computed.js
@@ -3,7 +3,7 @@ import {
   isPlainObject
 } from 'lodash'
 import makeComposedProps from './makeComposedProps'
-import Exception from '../utils/log'
+import { warn, Exception } from '../utils/log'
 
 /**
  * Creates a function that HelixSpec.generate can use to render computed
@@ -18,6 +18,8 @@ import Exception from '../utils/log'
  * @returns function
  */
 const computed = faker => (props, seedValue) => computedCallback => {
+  warn('Helix: faker.computed has been deprecated. Please use derived() instead.')
+
   if (!isPlainObject(props)) {
     throw new Exception(
       'faker.computed',

--- a/src/faker/computed.js
+++ b/src/faker/computed.js
@@ -30,9 +30,12 @@ const computed = faker => (props, seedValue) => computedCallback => {
       'faker.seed value must be a valid number.'
     )
   }
-  return (seedValue) => {
+  const generator = (seedValue) => {
     return computedCallback(makeComposedProps(faker)(props, seedValue))
   }
+  generator.fakerComputedValue = true
+
+  return generator
 }
 
 export default computed

--- a/src/faker/index.js
+++ b/src/faker/index.js
@@ -28,7 +28,5 @@ faker.seed = (...args) => fakerLib.seed(...args)
 faker.fake = (...args) => fakerLib.fake(...args)
 
 faker.computed = computed(faker)
-// Add property that allows generate() to check for computedProperty
-faker.computed.fakerComputedValue = true
 
 export default faker

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 export { default as compose } from './compose'
 export { default as createSpec } from './createSpec'
 export { default as faker } from './faker'
+export { default as derived } from './derived'
 export * from './helpers'

--- a/src/tests/index.test.js
+++ b/src/tests/index.test.js
@@ -1,6 +1,7 @@
 import {
   compose,
   createSpec,
+  derived,
   faker,
   oneOf
 } from '..'
@@ -11,6 +12,10 @@ test('compose should be exported', () => {
 
 test('createSpec should be exported', () => {
   expect(createSpec).toBeTruthy()
+})
+
+test('derived should be exported', () => {
+  expect(derived).toBeTruthy()
 })
 
 test('faker should be exported', () => {


### PR DESCRIPTION
## Add new `derived()` function for better computeds

### Feature / enhancement

🍐 with @alisdair to add a new function that allows you to create
computed values based on **existing data** within the shape of the Spec.

**Example**
```js
const Spec = createSpec({
  fname: () => 'Alice',
  lname: () => 'Baker',
  name: derived(({ fname, lname }) => `${fname} ${lname}`)
})
const fixture = Spec.generate()
```

**Output**
```
{
  fname: 'Alice',
  lname: 'Baker',
  name: 'Alice Baker'
}
```

@brettjonesdev Would love to know what you think of this! And if it's enough to take care of your use-case you pointed out in https://github.com/helpscout/helix/issues/11.

Either way, I really like this approach. It's **way** cleaner and simpler compared to the clunky/verbose `computed()` I previously wrote.

If you're down with this, I'll update docs and put a deprecation warning for `faker.computed()`.