### PR TITLE
Fix bug where `generate(0)` returns a single spec instance instead of empty array 

### DIFF
--- a/src/HelixSpec/index.js
+++ b/src/HelixSpec/index.js
@@ -24,8 +24,8 @@ class HelixSpec {
     return this
   }
 
-  generate (count = 0, max) {
-    if (!isNumber(count)) {
+  generate (count, max) {
+    if (!isNumber(count) && count !== undefined) {
       throw Exception('HelixSpec.generate()', 'Argument must be a valid number.')
     }
     if (max !== undefined) {
@@ -38,8 +38,7 @@ class HelixSpec {
       count = faker.random.number({min: count, max})
     }
 
-    // If count was 0, max was specified, but the randomized count comes back 0, return []
-    const isArray = count || max !== undefined
+    const isArray = isNumber(count)
     const generatedSpecs = isArray
       ? [...Array(count)].map(() => {
         // Respect seed value for multi-generated specs

--- a/src/HelixSpec/tests/generate.test.js
+++ b/src/HelixSpec/tests/generate.test.js
@@ -48,10 +48,10 @@ test('Throw if max argument is less than count argument', () => {
 })
 
 test('Generates fixtures from a spec object', () => {
-  const person = new HelixSpec({
+  const Person = new HelixSpec({
     id: faker.random.number()
   })
-  const fixture = person.generate()
+  const fixture = Person.generate()
 
   expect(fixture.id).toBeTruthy()
 })
@@ -68,6 +68,15 @@ test('Can generate multiple specs', () => {
 
   expect(Array.isArray(fixture)).toBeTruthy()
   expect(fixture[0].id).not.toBe(fixture[1].id)
+})
+
+test('Creates an empty array if we call generate(0)', () => {
+  const Person = new HelixSpec({
+    id: faker.random.number()
+  })
+
+  const fixture = Person.generate(0)
+  expect(fixture).toEqual([])
 })
 
 test('Can generate nested un-generated spec', () => {


### PR DESCRIPTION
`Spec.generate(0)` ought to return an empty array, but right now it returns the same as `Spec.generate()`. This PR fixes this behavior. 