### PR TITLE
Add beforeGenerate and afterGenerate hooks

### DIFF
--- a/docs/api/HelixSpec/README.md
+++ b/docs/api/HelixSpec/README.md
@@ -28,5 +28,7 @@ const Dinosaur = createSpec({
 HelixSpec contains a handful of methods:
 
 * [extend](./extend.md)
+* [beforeGenerate](./beforeGenerate.md)
 * [generate](./generate.md)
+* [afterGenerate](./beforeGenerate.md)
 * [seed](./seed.md)

--- a/docs/api/HelixSpec/afterGenerate.md
+++ b/docs/api/HelixSpec/afterGenerate.md
@@ -1,0 +1,45 @@
+# `afterGenerate(callback(data) => { ... })`
+
+A hook to adjust the fixture output (`object`) of the HelixSpec that is called right after the fixture is [generated](./generate.md).
+
+
+### Arguments
+
+| Argument | Type | Description |
+| --- | --- | --- |
+| `callback` | `function` | Callback function to adjust the fixture data. |
+| `data` | `object` | Generated fixture data passed into the `callback`. |
+
+
+### Returns
+
+`HelixSpec`: Returns itself.
+
+
+### Example
+
+```js
+const Dinosaur = createSpec({
+  id: faker.random.number(),
+  name: faker.name.firstName(),
+  location: faker.address.country()
+})
+
+Dinosaur.afterGenerate(data => {
+  const { name } = data
+  return {
+    name,
+    location: 'Mexico',
+    status: 'Happy',
+    email: 'noop@superprivacy.com'
+  }
+})
+
+Dinosaur.generate()
+// {
+//   name: 'Alice',
+//   location: 'Mexico'
+//   status: 'Happy',
+//   email: 'noop@superprivacy.com'
+// }
+```

--- a/docs/api/HelixSpec/beforeGenerate.md
+++ b/docs/api/HelixSpec/beforeGenerate.md
@@ -1,0 +1,47 @@
+# `beforeGenerate(callback(shape) => { ... })`
+
+A hook to adjust the shape (`object`) of the HelixSpec that is called right before the fixture is [generated](./generate.md).
+
+
+### Arguments
+
+| Argument | Type | Description |
+| --- | --- | --- |
+| `callback` | `function` | Callback function to adjust the Helix shape. |
+| `shape` | `object` | Helix shape passed into the `callback`. |
+
+
+### Returns
+
+`HelixSpec`: Returns itself.
+
+
+### Example
+
+```js
+const Dinosaur = createSpec({
+  id: faker.random.number(),
+  name: faker.name.firstName(),
+  location: faker.address.country()
+})
+
+Dinosaur.beforeGenerate(shape => {
+  const { id, name } = shape
+  return {
+    id,
+    name,
+    location: 'Mexico',
+    status: 'Happy',
+    email: faker.internet.email()
+  }
+})
+
+Dinosaur.generate()
+// {
+//   id: 1231,
+//   name: 'Alice',
+//   location: 'Mexico'
+//   status: 'Happy',
+//   email: 'alice@dinosaur.us'
+// }
+```

--- a/docs/api/HelixSpec/extend.md
+++ b/docs/api/HelixSpec/extend.md
@@ -11,7 +11,7 @@ Extends the spec shape of the HelixSpec.
 
 ### Returns
 
-`HelixSpec`: Renders itself.
+`HelixSpec`: Return itself.
 
 
 ### Example

--- a/src/HelixSpec/index.js
+++ b/src/HelixSpec/index.js
@@ -1,5 +1,5 @@
 import faker from 'faker'
-import { isNumber } from 'lodash'
+import { isFunction, isNumber } from 'lodash'
 import Exception from '../utils/log'
 import generateSpecs from './generateSpecs'
 
@@ -16,11 +16,28 @@ class HelixSpec {
   constructor (shape) {
     this.shape = shape
     this.seedValue = undefined
+    this._afterGenerate = props => props
     return this
   }
 
   extend (...specs) {
     this.shape = Object.assign(this.shape, ...specs)
+    return this
+  }
+
+  beforeGenerate (callback) {
+    if (!isFunction(callback)) {
+      throw Exception('HelixSpec.beforeGenerate()', 'Argument must be a valid function.')
+    }
+    this.shape = callback(this.shape)
+    return this
+  }
+
+  afterGenerate (callback) {
+    if (!isFunction(callback)) {
+      throw Exception('HelixSpec.afterGenerate()', 'Argument must be a valid function.')
+    }
+    this._afterGenerate = callback
     return this
   }
 
@@ -49,7 +66,7 @@ class HelixSpec {
       : generateSpecs(this.shape, this.seedValue)
 
     this.seedValue = undefined
-    return generatedSpecs
+    return this._afterGenerate(generatedSpecs)
   }
 
   seed (seedValue) {

--- a/src/HelixSpec/tests/afterGenerate.test.js
+++ b/src/HelixSpec/tests/afterGenerate.test.js
@@ -1,0 +1,33 @@
+import HelixSpec from '..'
+import faker from '../../faker'
+
+test('Throw if argument is invalid', () => {
+  const person = new HelixSpec({
+    id: faker.random.number()
+  })
+  expect(() => { person.afterGenerate(true) }).toThrow()
+  expect(() => { person.afterGenerate('name') }).toThrow()
+  expect(() => { person.afterGenerate(false) }).toThrow()
+})
+
+test('Can adjust data after generating', () => {
+  const person = new HelixSpec({
+    id: faker.random.uuid(),
+    number: faker.random.number()
+  })
+  person.afterGenerate(data => {
+    return {
+      name: 'Alice',
+      prevNumber: data.number,
+      number: 123
+    }
+  })
+
+  const fixture = person.generate()
+
+  expect(typeof fixture.id).toBe('undefined')
+  expect(fixture.name).toBe('Alice')
+  expect(fixture.number).toBe(123)
+  expect(typeof fixture.prevNumber).toBe('number')
+})
+

--- a/src/HelixSpec/tests/beforeGenerate.test.js
+++ b/src/HelixSpec/tests/beforeGenerate.test.js
@@ -1,0 +1,31 @@
+import HelixSpec from '..'
+import faker from '../../faker'
+
+test('Throw if argument is invalid', () => {
+  const person = new HelixSpec({
+    id: faker.random.number()
+  })
+  expect(() => { person.beforeGenerate(true) }).toThrow()
+  expect(() => { person.beforeGenerate('name') }).toThrow()
+  expect(() => { person.beforeGenerate(false) }).toThrow()
+})
+
+test('Can adjust shape before generating', () => {
+  const person = new HelixSpec({
+    id: faker.random.uuid()
+  })
+  person.beforeGenerate(({ id }) => {
+    return {
+      id,
+      name: 'Alice',
+      number: faker.random.number()
+    }
+  })
+
+  const fixture = person.generate()
+
+  expect(typeof fixture.id).toBe('string')
+  expect(fixture.name).toBe('Alice')
+  expect(typeof fixture.number).toBe('number')
+})
+


### PR DESCRIPTION
## Add beforeGenerate and afterGenerate hooks

This update adds two new hook methods to `HelixSpec`: `beforeGenerate`
and `afterGenerate`.

These hooks allow you easily to adjust the shape/fixture data of
your specs, which can be handy for create alternate specs.

**Example: `afterGenerate()`**

```js
const Dinosaur = createSpec({
  id: faker.random.number(),
  name: faker.name.firstName(),
  location: faker.address.country()
})

Dinosaur.afterGenerate(data => {
  const { name } = data
  return {
    name,
    location: 'Mexico',
    status: 'Happy',
    email: 'noop@superprivacy.com'
  }
})

Dinosaur.generate()
// {
//   name: 'Alice',
//   location: 'Mexico'
//   status: 'Happy',
//   email: 'noop@superprivacy.com'
// }
```

cc'ing @brettjonesdev  ;)

Resolves: https://github.com/helpscout/helix/issues/11