### PR TITLE
Fix `oneOf` export so that hs-app can import that helper

### DIFF
--- a/src/HelixSpec/tests/afterGenerate.test.js
+++ b/src/HelixSpec/tests/afterGenerate.test.js
@@ -30,4 +30,3 @@ test('Can adjust data after generating', () => {
   expect(fixture.number).toBe(123)
   expect(typeof fixture.prevNumber).toBe('number')
 })
-

--- a/src/HelixSpec/tests/beforeGenerate.test.js
+++ b/src/HelixSpec/tests/beforeGenerate.test.js
@@ -28,4 +28,3 @@ test('Can adjust shape before generating', () => {
   expect(fixture.name).toBe('Alice')
   expect(typeof fixture.number).toBe('number')
 })
-

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -1,1 +1,0 @@
-export { default as oneOf } from './oneOf'

--- a/src/index.js
+++ b/src/index.js
@@ -2,5 +2,4 @@ export { default as compose } from './compose'
 export { default as createSpec } from './createSpec'
 export { default as faker } from './faker'
 export { default as derived } from './derived'
-
-export { default as oneOf } from './helpers/oneOf'
+export { default as oneOf } from './oneOf'

--- a/src/index.js
+++ b/src/index.js
@@ -2,4 +2,5 @@ export { default as compose } from './compose'
 export { default as createSpec } from './createSpec'
 export { default as faker } from './faker'
 export { default as derived } from './derived'
-export * from './helpers'
+
+export { default as oneOf } from './helpers/oneOf'

--- a/src/oneOf/index.js
+++ b/src/oneOf/index.js
@@ -1,7 +1,7 @@
-import HelixSpec from '../../HelixSpec'
-import faker from '../../faker/'
-import generateSpecs from '../../HelixSpec/generateSpecs'
-import { Exception } from '../../utils/log'
+import HelixSpec from '../HelixSpec/index'
+import faker from '../faker/index'
+import generateSpecs from '../HelixSpec/generateSpecs'
+import { Exception } from '../utils/log'
 
 /**
  * Combines both HelixSpec class instance and regular objects to create a single

--- a/src/oneOf/tests/oneOf.test.js
+++ b/src/oneOf/tests/oneOf.test.js
@@ -1,9 +1,9 @@
 import { times } from 'lodash'
-import oneOf from '../'
-import HelixSpec from '../../../HelixSpec'
-import compose from '../../../compose'
-import faker from '../../../faker'
-import { Exception } from '../../../utils/log'
+import oneOf from '../index'
+import HelixSpec from '../../HelixSpec/index'
+import compose from '../../compose/index'
+import faker from '../../faker/index'
+import { Exception } from '../../utils/log'
 
 describe('oneOf tests', () => {
   test('Should throw if argument(s) are invalid', () => {


### PR DESCRIPTION
## Fix `oneOf` export so that hs-app can import that helper

Change how we export `oneOf` to no longer use the `export * from './helpers'` format, since that way does not work properly with hs-app's webpack config (since tree shaking doesn't work quite right out of the box we had to shim the helix webpack config)