### PR TITLE
Seeding: Generating different + consistent values for multiple fixtures

### DIFF
--- a/src/HelixSpec/index.js
+++ b/src/HelixSpec/index.js
@@ -13,62 +13,78 @@ import generateSpecs from './generateSpecs'
  * @returns class
  */
 class HelixSpec {
-  constructor (shape) {
+  constructor(shape) {
     this.shape = shape
     this.seedValue = undefined
     this._afterGenerate = props => props
     return this
   }
 
-  extend (...specs) {
+  extend(...specs) {
     this.shape = Object.assign(this.shape, ...specs)
     return this
   }
 
-  beforeGenerate (callback) {
+  beforeGenerate(callback) {
     if (!isFunction(callback)) {
-      throw Exception('HelixSpec.beforeGenerate()', 'Argument must be a valid function.')
+      throw Exception(
+        'HelixSpec.beforeGenerate()',
+        'Argument must be a valid function.'
+      )
     }
     this.shape = callback(this.shape)
     return this
   }
 
-  afterGenerate (callback) {
+  afterGenerate(callback) {
     if (!isFunction(callback)) {
-      throw Exception('HelixSpec.afterGenerate()', 'Argument must be a valid function.')
+      throw Exception(
+        'HelixSpec.afterGenerate()',
+        'Argument must be a valid function.'
+      )
     }
     this._afterGenerate = callback
     return this
   }
 
-  generate (count, max) {
+  generate(count, max) {
     if (!isNumber(count) && count !== undefined) {
-      throw Exception('HelixSpec.generate()', 'Argument must be a valid number.')
+      throw Exception(
+        'HelixSpec.generate()',
+        'Argument must be a valid number.'
+      )
     }
     if (max !== undefined) {
       if (!isNumber(max)) {
-        throw Exception('HelixSpec.generate()', 'Max argument must be a valid number.')
+        throw Exception(
+          'HelixSpec.generate()',
+          'Max argument must be a valid number.'
+        )
       }
       if (max <= count) {
-        throw Exception('HelixSpec.generate()', 'Max argument must be larger than count argument.')
+        throw Exception(
+          'HelixSpec.generate()',
+          'Max argument must be larger than count argument.'
+        )
       }
-      count = faker.random.number({min: count, max})
+      count = faker.random.number({ min: count, max })
     }
 
     const isArray = isNumber(count)
+    const _seedValue = this.seedValue
     const generatedSpecs = isArray
-      ? [...Array(count)].map(() => {
-        // Respect seed value for multi-generated specs
-        this.seed(this.seedValue)
-        return generateSpecs(this.shape, this.seedValue)
-      })
+      ? [...Array(count)].map((n, index) => {
+          // Respect seed value for multi-generated specs
+          this.seed(_seedValue + index)
+          return generateSpecs(this.shape, this.seedValue)
+        })
       : generateSpecs(this.shape, this.seedValue)
 
     this.seedValue = undefined
     return this._afterGenerate(generatedSpecs)
   }
 
-  seed (seedValue) {
+  seed(seedValue) {
     if (seedValue !== undefined && !isNumber(seedValue)) {
       throw new Exception(
         'HelixSpec.seed()',

--- a/src/HelixSpec/tests/seed.test.js
+++ b/src/HelixSpec/tests/seed.test.js
@@ -3,18 +3,26 @@ import faker from '../../faker'
 
 test('Throws if argument is invalid', () => {
   const person = new HelixSpec({
-    name: faker.name.firstName()
+    name: faker.name.firstName(),
   })
 
-  expect(() => { person.seed() }).not.toThrow()
-  expect(() => { person.seed('1') }).toThrow()
-  expect(() => { person.seed(true) }).toThrow()
-  expect(() => { person.seed({value: 2}) }).toThrow()
+  expect(() => {
+    person.seed()
+  }).not.toThrow()
+  expect(() => {
+    person.seed('1')
+  }).toThrow()
+  expect(() => {
+    person.seed(true)
+  }).toThrow()
+  expect(() => {
+    person.seed({ value: 2 })
+  }).toThrow()
 })
 
 test('Can be set', () => {
   const person = new HelixSpec({
-    name: faker.name.firstName()
+    name: faker.name.firstName(),
   })
 
   const one = person.seed(1).generate()
@@ -31,7 +39,7 @@ test('Can be set', () => {
 
 test('Is unaffected by external faker.seed', () => {
   const person = new HelixSpec({
-    name: faker.name.firstName()
+    name: faker.name.firstName(),
   })
 
   faker.seed(4)
@@ -48,16 +56,38 @@ test('Is unaffected by external faker.seed', () => {
   expect(one.name).toBe(three.name)
 })
 
-test('Can generate multiple specs, but with the same seed', () => {
+test('Can seed + generate multiple specs', () => {
   const MessageSpec = new HelixSpec({
     id: faker.random.number(),
     read: faker.random.boolean(),
     timestamp: faker.date.past(),
-    message: faker.lorem.paragraph()
+    message: faker.lorem.paragraph(),
   })
 
   const fixture = MessageSpec.seed(2).generate(5)
 
   expect(Array.isArray(fixture)).toBeTruthy()
-  expect(fixture[0].id).toBe(fixture[1].id)
+  expect(fixture[0].id).not.toBe(fixture[1].id)
+  expect(fixture[0].id).not.toBe(fixture[2].id)
+  expect(fixture[0].id).not.toBe(fixture[3].id)
+  expect(fixture[0].id).not.toBe(fixture[4].id)
+})
+
+test('Can seed + generate multiple specs with consistent seed values', () => {
+  const MessageSpec = new HelixSpec({
+    id: faker.random.number(),
+  })
+
+  const fixture = MessageSpec.seed(2).generate(5)
+
+  faker.seed(2)
+  expect(fixture[0].id).toBe(faker.random.number()())
+  faker.seed(3)
+  expect(fixture[1].id).toBe(faker.random.number()())
+  faker.seed(4)
+  expect(fixture[2].id).toBe(faker.random.number()())
+  faker.seed(5)
+  expect(fixture[3].id).toBe(faker.random.number()())
+  faker.seed(6)
+  expect(fixture[4].id).toBe(faker.random.number()())
 })


### PR DESCRIPTION
## Seeding: Generating different + consistent values for multiple fixtures

This update fixes the `generate` method for `HelixSpec` which ensures that if
multiple fixtures are being generated, then all of those fixtures use a
different seed index.

This allows for multiple fixtures to be consistently seeded, but have different
seeded results.

The generate accepts the initial seed value (e.g. 2), and increments it for
every iteration that it generates (e.g. 2, 3, 4, 5).

Resolves: https://github.com/helpscout/helix/issues/20